### PR TITLE
ReportElement object, with —json option and human output

### DIFF
--- a/riffdog/data_structures.py
+++ b/riffdog/data_structures.py
@@ -1,0 +1,45 @@
+"""
+This module exists to hold data structures common across modules, the scanner
+and the command line interface
+"""
+
+from enum import Enum
+
+class ScanMode(Enum):
+    """
+    Mode of operation of scanner
+    """
+
+    LIGHT = 1
+    DEEP = 2
+
+
+class StateStorage(Enum):
+    AWS_S3 = 1
+    # FILE = 2
+
+
+class RDConfig():
+    """
+    RiffDog Config Object for controlling the scan.
+    """
+
+    scan_mode = ScanMode.LIGHT
+
+    state_storage = StateStorage.AWS_S3
+    state_file_locations = []
+    regions = ['us-east-1']
+
+    elements_to_scan = [
+        'aws_instances'
+    ]
+
+
+class ReportElement():
+    """
+    Output report object for reporting things it finds.
+    """
+
+    matched = []
+    in_tf_but_not_aws = []
+    in_aws_but_not_tf = []

--- a/riffdog/modules/ec2_instances.py
+++ b/riffdog/modules/ec2_instances.py
@@ -5,6 +5,7 @@ This module is for EC2 instance processing - terraform & boto and comparison.
 import logging
 
 from ..utils import _get_client, _get_resource
+from ..data_structures import ReportElement
 
 logger = logging.getLogger(__name__)
 
@@ -102,16 +103,22 @@ def _boto_fetch_instances(region):
 def _compare_instances(tf_instances, boto_instances, config):
     #FIXME: lightweight scan now!
 
+    out_report = ReportElement()
+
     tf_ids = tf_instances.keys()
     aws_ids = boto_instances.keys()
 
     for key, val in tf_instances.items():
         if key not in aws_ids:
-            print("Terraform server %s no longer real" % key)
+            out_report.in_tf_but_not_aws.append(key)
+        else:
+            out_report.matched.append(key)
 
     for key, val in boto_instances.items():
         if key not in tf_ids:
-            print("AWS instance %s not in terraform" % key)
+            out_report.in_aws_but_not_tf.append(key)
+
+    return out_report
 
 
 

--- a/riffdog/scanner.py
+++ b/riffdog/scanner.py
@@ -69,11 +69,6 @@ def scan(config):
 
     logger.info("Now Looking at AWS (via Boto)")
 
-    real_items = _get_blank_state_dict()
-    
-    for region in config.regions:
-       real_items['aws_instances'].update(_boto_fetch_instances(region))
-
     report = {}
 
     for scan_element in config.elements_to_scan:


### PR DESCRIPTION
* also contains framework to allow ‘elements_to_scan’ to be a future config
* move towards using terraform defined strings for elements i.e. aws_instance rather then other magic strings.

Implements #1 