### PR TITLE
Adding tabular output and --show-matched flag.

### DIFF
--- a/riffdog/command_line.py
+++ b/riffdog/command_line.py
@@ -1,6 +1,9 @@
-import logging 
-import argparse 
+import logging
+import argparse
+
 from json import dumps, JSONEncoder
+
+from tabulate import tabulate
 
 from .scanner import scan
 from .data_structures import RDConfig, StateStorage, ScanMode, ReportElement
@@ -32,6 +35,7 @@ def main(*args):
     parser.add_argument('-v', '--verbose', help='Run in Verbose mode (try -vv for info output)', action='count')
     parser.add_argument('-b', '--bucket', help='Bucket containing state file location', action='append', nargs=1)
     parser.add_argument('--json', help='Produce Json output rather then Human Readble', action='store_const', const=True)
+    parser.add_argument('--show-matched', help='Shows all resources, including those that matched', action='store_const', const=True)
 
 
     # Parse args.
@@ -58,34 +62,30 @@ def main(*args):
     config = RDConfig()
 
     config.state_storage = StateStorage.AWS_S3
-    
+
     if parsed_args.bucket != None:
         config.state_file_locations = parsed_args.bucket[0]
-    
+
     # 3. Start scans
     results = scan(config)
 
     if parsed_args.json:
         print(dumps(results, cls=ReportEncoder))
     else:
+
         for key, report in results.items():
-            print("Inspected %s" % key)
-            
-            print("\tMatched ok:")
-            for element in report.matched:
-                print("\t\t%s" % element)
+            table_data = [[key, e, "✓", "x"] for e in report.in_aws_but_not_tf]
+            table_data += [[key, e, "x", "✓"] for e in report.in_tf_but_not_aws]
 
-            print("\tIn Terraform but NOT in AWS:")
-            for element in report.in_tf_but_not_aws:
-                print("\t\t%s" % element)
-    
-            print("\tIn AWS but NOT in Terraform:")
-            for element in report.in_aws_but_not_tf:
-                print("\t\t%s" % element)
+            if parsed_args.show_matched:
+                table_data += [[key, e, "✓", "✓"] for e in report.matched]
+                table_data.reverse()   # We want matched at the top (a bit more out the way), a but more human friendly.
 
-            print("----")
+        print(tabulate(
+            table_data,
+            headers=["Resource Type", "Identifier", "AWS", "Terraform"]))
+
+        print("-------------------------")
         print ("Please note, for elements in AWS but not in Terraform, make sure you've scanned all your state files.")
     # 4. Report
     logger.debug("Cmd finished")
-
-

--- a/riffdog/data_structures.py
+++ b/riffdog/data_structures.py
@@ -31,7 +31,7 @@ class RDConfig():
     regions = ['us-east-1']
 
     elements_to_scan = [
-        'aws_instances'
+        'aws_instance'
     ]
 
 

--- a/riffdog/scanner.py
+++ b/riffdog/scanner.py
@@ -29,7 +29,7 @@ _ignore_types = (
                )
 
 _scan_map = {
-    'aws_instances': { 'aws_scan_func': _boto_fetch_instances, 'compare_func': _compare_instances }
+    'aws_instance': { 'aws_scan_func': _boto_fetch_instances, 'compare_func': _compare_instances }
 }
 
 
@@ -85,7 +85,7 @@ def scan(config):
 
 def _get_blank_state_dict():
     return {
-        "aws_instances": {},
+        "aws_instance": {},
         "buckets": {},
         "rds": {}
     }
@@ -135,7 +135,7 @@ def search_state(bucket_name, key, s3):
 
             elif res['type'] == "aws_instance":
                 found = _tf_process_instances(res, key)
-                outs['aws_instances'].update(found)
+                outs['aws_instance'].update(found)
 
             elif res['type']=="aws_s3_bucket":
                 found = _process_s3(res, key)


### PR DESCRIPTION
Added
- New tabular output to make it a little more human friendly and readable.
- New --show-matched flag to show *all* resources even if they were OK. By default these will not show.

Fixed
- Renamed `aws_instances` to `aws_instance` so it matches up with the official Terraform resource address. Moving forward this should be the way to go, despite their differences in conventions. It will be more intuitive to users who are using TF all day every day.