### PR TITLE
S3 scanner resource name

### DIFF
--- a/riffdog/resources/s3_buckets.py
+++ b/riffdog/resources/s3_buckets.py
@@ -1,5 +1,5 @@
 """
-This module is for EC2 instance processing - terraform & boto and comparison.
+This module is for S3 bucket processing - terraform & boto and comparison.
 """
 
 import logging
@@ -8,11 +8,11 @@ from ..resource import AWSResource, register
 
 logger = logging.getLogger(__name__)
 
+
 @register("aws_s3_bucket")
 class S3Buckets(AWSResource):
     _states_found = {}
     _real_buckets = {}
-
 
     def fetch_real_resources(self, region):
         logging.info("Looking for s3 resources")
@@ -24,11 +24,8 @@ class S3Buckets(AWSResource):
         for bucket in response['Buckets']:
             self._real_buckets[bucket['Name']] = bucket
 
-        
     def process_state_resource(self, state_resource, state_filename):
-        
         self._states_found[state_resource['name']] = state_resource
-
 
     def compare(self, config, depth):
         # this function should be called once, take the local data and return
@@ -52,6 +49,5 @@ class S3Buckets(AWSResource):
             if key not in self._states_found:
                 out_report.in_real_but_not_tf.append(key)
 
-        print()
         return out_report
 

--- a/riffdog/resources/s3_buckets.py
+++ b/riffdog/resources/s3_buckets.py
@@ -36,7 +36,14 @@ class S3Buckets(AWSResource):
         out_report = ReportElement()
 
         for key, val in self._states_found.items():
-            if key not in self._real_buckets:
+            # This could probably be improved somewhat and it doesn't really take into account if there's more than
+            # one instance here. I would assume there wouldn't be, but who knows?
+            try:
+                real_bucket_name = val['instances'][0]['attributes']['bucket']
+            except (KeyError, IndexError):
+                real_bucket_name = key
+
+            if real_bucket_name not in self._real_buckets:
                 out_report.in_tf_but_not_real.append(key)
             else:
                 out_report.matched.append(key)


### PR DESCRIPTION
Don't make the assumption that the terraform resource name is the same as the bucket name.

Fixes #18 