### PR TITLE
Adding basics for RDS Clusters (cluster, instances and param groups)

### DIFF
--- a/riffdog/data_structures.py
+++ b/riffdog/data_structures.py
@@ -32,7 +32,10 @@ class RDConfig():
 
     elements_to_scan = [
         'aws_instance',
-        'aws_s3_bucket'
+        'aws_s3_bucket',
+        'aws_rds_cluster',
+        'aws_rds_cluster_instance',
+        'aws_rds_cluster_parameter_group'
     ]
 
 

--- a/riffdog/data_structures.py
+++ b/riffdog/data_structures.py
@@ -35,7 +35,8 @@ class RDConfig():
         'aws_s3_bucket',
         'aws_rds_cluster',
         'aws_rds_cluster_instance',
-        'aws_rds_cluster_parameter_group'
+        'aws_rds_cluster_parameter_group',
+        'aws_db_instance',
     ]
 
 

--- a/riffdog/resource.py
+++ b/riffdog/resource.py
@@ -16,7 +16,7 @@ class ResourceDirectory(object):
             self.found_resources = {}
 
         def __str__(self):
-            return str(found_resources)
+            return str(self.found_resources)
 
         def add(self, key, target_type):
             self.found_resources[key] = target_type

--- a/riffdog/resources/rds/cluster_parameter_group.py
+++ b/riffdog/resources/rds/cluster_parameter_group.py
@@ -1,0 +1,45 @@
+"""
+This module is for RDS Cluster Parameter Groups
+"""
+
+import logging
+
+from riffdog.data_structures import ReportElement
+from riffdog.resource import AWSResource, register
+
+logger = logging.getLogger(__name__)
+
+
+@register("aws_rds_cluster_parameter_group")
+class AWSRDSParameterGroup(AWSResource):
+    _cluster_pgs_in_aws = {}
+    _cluster_pgs_in_state = {}
+
+    def fetch_real_resources(self, region):
+        logging.info("Looking for RDS resources")
+
+        client = self._get_client("rds", region)
+
+        response = client.describe_db_cluster_parameter_groups()
+
+        for pg in response["DBClusterParameterGroups"]:
+            self._cluster_pgs_in_aws[pg["DBClusterParameterGroupName"]] = pg
+
+    def process_state_resource(self, state_resource, state_filename):
+        for instance in state_resource["instances"]:
+            self._cluster_pgs_in_state[instance["attributes"]["cluster_identifier"]] = instance
+
+    def compare(self, config, depth):
+        out_report = ReportElement()
+
+        for key, val in self._cluster_pgs_in_state.items():
+            if key not in self._cluster_pgs_in_aws:
+                out_report.in_tf_but_not_real.append(key)
+            else:
+                out_report.matched.append(key)
+
+        for key, val in self._cluster_pgs_in_aws.items():
+            if key not in self._cluster_pgs_in_state:
+                out_report.in_real_but_not_tf.append(key)
+
+        return out_report

--- a/riffdog/resources/rds/cluster_parameter_group.py
+++ b/riffdog/resources/rds/cluster_parameter_group.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 @register("aws_rds_cluster_parameter_group")
-class AWSRDSParameterGroup(AWSResource):
+class AWSRDSClusterParameterGroup(AWSResource):
     _cluster_pgs_in_aws = {}
     _cluster_pgs_in_state = {}
 

--- a/riffdog/resources/rds/db_cluster.py
+++ b/riffdog/resources/rds/db_cluster.py
@@ -1,0 +1,86 @@
+"""
+This module is for RDS Clusters
+"""
+
+import logging
+
+from riffdog.data_structures import ReportElement
+from riffdog.resource import AWSResource, register
+
+logger = logging.getLogger(__name__)
+
+
+@register("aws_rds_cluster")
+class AWSRDSCluster(AWSResource):
+    _clusters_in_aws = {}
+    _clusters_in_state = {}
+
+    def fetch_real_resources(self, region):
+        logging.info("Looking for RDS resources")
+
+        client = self._get_client("rds", region)
+
+        response = client.describe_db_clusters()
+
+        for cluster in response["DBClusters"]:
+            self._clusters_in_aws[cluster["DBClusterIdentifier"]] = cluster
+
+    def process_state_resource(self, state_resource, state_filename):
+        for instance in state_resource["instances"]:
+            self._clusters_in_state[instance["attributes"]["cluster_identifier"]] = instance
+
+    def compare(self, config, depth):
+        out_report = ReportElement()
+
+        for key, val in self._clusters_in_state.items():
+            if key not in self._clusters_in_aws:
+                out_report.in_tf_but_not_real.append(key)
+            else:
+                out_report.matched.append(key)
+
+        for key, val in self._clusters_in_aws.items():
+            if key not in self._clusters_in_state:
+                out_report.in_real_but_not_tf.append(key)
+
+        return out_report
+
+
+@register("aws_rds_cluster_instance")
+class AWSRDSClusterInstance(AWSResource):
+    """
+    These are a faux thing to Terraform. An aws_rds_cluster_instance is
+    just an aws_db_instance that belongs to a Cluster.
+    """
+    _instances_in_aws = {}
+    _instances_in_state = {}
+
+    def fetch_real_resources(self, region):
+        logging.info("Looking for RDS resources")
+
+        client = self._get_client("rds", region)
+
+        response = client.describe_db_instances()
+
+        for instance in response["DBInstances"]:
+            if "DBClusterIdentifier" in instance:
+                if instance["DBClusterIdentifier"]:
+                    self._instances_in_aws[instance["DBInstanceIdentifier"]] = instance
+
+    def process_state_resource(self, state_resource, state_filename):
+        for instance in state_resource["instances"]:
+            self._instances_in_state[instance["attributes"]["identifier"]] = instance
+
+    def compare(self, config, depth):
+        out_report = ReportElement()
+
+        for key, val in self._instances_in_state.items():
+            if key not in self._instances_in_aws:
+                out_report.in_tf_but_not_real.append(key)
+            else:
+                out_report.matched.append(key)
+
+        for key, val in self._instances_in_aws.items():
+            if key not in self._instances_in_state:
+                out_report.in_real_but_not_tf.append(key)
+
+        return out_report

--- a/riffdog/resources/rds/db_instance.py
+++ b/riffdog/resources/rds/db_instance.py
@@ -1,0 +1,45 @@
+import logging
+
+from riffdog.data_structures import ReportElement
+from riffdog.resource import AWSResource, register
+
+logger = logging.getLogger(__name__)
+
+
+@register("aws_db_instance")
+class AWSRDSClusterInstance(AWSResource):
+    """
+    These are a faux thing to Terraform. An aws_rds_cluster_instance is
+    just an aws_db_instance that belongs to a Cluster.
+    """
+    _instances_in_aws = {}
+    _instances_in_state = {}
+
+    def fetch_real_resources(self, region):
+        logger.info("Looking for RDS resources")
+
+        client = self._get_client("rds", region)
+
+        response = client.describe_db_instances()
+
+        for instance in response["DBInstances"]:
+            self._instances_in_aws[instance["DBInstanceIdentifier"]] = instance
+
+    def process_state_resource(self, state_resource, state_filename):
+        for instance in state_resource["instances"]:
+            self._instances_in_state[instance["attributes"]["id"]] = instance
+
+    def compare(self, config, depth):
+        out_report = ReportElement()
+
+        for key, val in self._instances_in_state.items():
+            if key not in self._instances_in_aws:
+                out_report.in_tf_but_not_real.append(key)
+            else:
+                out_report.matched.append(key)
+
+        for key, val in self._instances_in_aws.items():
+            if key not in self._instances_in_state:
+                out_report.in_real_but_not_tf.append(key)
+
+        return out_report

--- a/riffdog/resources/rds/db_instance.py
+++ b/riffdog/resources/rds/db_instance.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 
 @register("aws_db_instance")
-class AWSRDSClusterInstance(AWSResource):
+class AWSDBInstance(AWSResource):
     """
     These are a faux thing to Terraform. An aws_rds_cluster_instance is
     just an aws_db_instance that belongs to a Cluster.

--- a/riffdog/scanner.py
+++ b/riffdog/scanner.py
@@ -33,9 +33,14 @@ def scan(config):
     # Build scan map:
     rd = ResourceDirectory()
 
-    for (_, name, _) in pkgutil.iter_modules([os.path.join(os.path.dirname(__file__),"resources")]):
-        imported_module = import_module('riffdog.resources.%s' % name)
-
+    for (_, name, is_package) in pkgutil.walk_packages([os.path.join(os.path.dirname(__file__), "resources")]):
+        if is_package:
+            package_name = name
+            for (_, name, _) in pkgutil.iter_modules([os.path.join(os.path.dirname(__file__), "resources", package_name)]):
+                import_module('riffdog.resources.%s.%s' % (package_name, name))
+        else:
+            for (_, name, _) in pkgutil.iter_modules([os.path.join(os.path.dirname(__file__), "resources")]):
+                import_module('riffdog.resources.%s' % name)
 
     if config.state_storage == StateStorage.AWS_S3:
         # Note we don't support mix & match state locations.


### PR DESCRIPTION
Implements https://github.com/jmons/riffdog/issues/17

Added
- RDS Cluster basics (cluster, instances, parameter groups.

Fixed
- Minor bug where the ResourceDirectory didnt have self in its __str__.
- In order to support foldered module structure, the dynamic importing has changed a little.

