### PR TITLE
Fix `--exclude-resource` support and add `--include-resource` support

### DIFF
--- a/riffdog/command_line.py
+++ b/riffdog/command_line.py
@@ -77,6 +77,7 @@ def _add_core_arguments(parser):
     parser.add_argument('--json', help='Produce Json output rather then Human readble', action='store_const', const=True)  # noqa: E501
     parser.add_argument('--show-matched', help='Shows all resources, including those that matched', action='store_const', const=True)  # noqa: E501
     parser.add_argument('--exclude-resource', help="Excludes a particular resource", action='append', default=[])
+    parser.add_argument('--include-resource', help="Includes a particular resource", action="append", default=[])
     
 
 def main(*args):
@@ -112,6 +113,8 @@ def main(*args):
     config = RDConfig()
 
     config.external_resource_libs += pre_parsed_args.include
+    config.excluded_resources = pre_parsed_args.exclude_resource
+    config.included_resources = pre_parsed_args.include_resource
 
     find_arguments(parser, config.external_resource_libs)
     

--- a/riffdog/config.py
+++ b/riffdog/config.py
@@ -24,8 +24,11 @@ class RDConfig:
 
         @property
         def elements_to_scan(self):
-            return (x for x in self.base_elements_to_scan if x not in self.excluded_resources)
-
+            if self.included_resources:
+                resources = (x for x in self.included_resources)
+            else:
+                resources = (x for x in self.base_elements_to_scan if x not in self.excluded_resources)
+            return resources
 
         def __init__(self):
             # Set defaults and must-have settings
@@ -37,6 +40,7 @@ class RDConfig:
             self.state_file_locations = []
 
             self.excluded_resources = []
+            self.included_resources = []
 
             self.base_elements_to_scan = []
 

--- a/riffdog/scanner.py
+++ b/riffdog/scanner.py
@@ -150,6 +150,7 @@ def _search_state(bucket_name, key, s3):
     obj = s3.Object(bucket_name, key)
     content = obj.get()['Body'].read()
     rd = ResourceDirectory()
+    config = RDConfig()
     parsed = ""
     try:
         parsed = json.loads(content)
@@ -160,11 +161,14 @@ def _search_state(bucket_name, key, s3):
             elements = parsed['modules'][0]['resources'].values()
 
         for res in elements:
-            element = rd.lookup(res['type'])
-            if element:
-                element.process_state_resource(res, key)
+            if res['type'] in config.elements_to_scan:
+                element = rd.lookup(res['type'])
+                if element:
+                    element.process_state_resource(res, key)
+                else:
+                    logging.debug(" Unsupported resource %s" % res['type'])
             else:
-                logging.debug(" Unsupported resource %s" % res['type'])
+                logging.debug("Skipped %s as not in elments to scan" % res['type'])
 
     except Exception as e:
         # FIXME: tighten this up could be - file not Json issue, permission of s3 etc, as well as the terraform state

--- a/tests/test_data_structures.py
+++ b/tests/test_data_structures.py
@@ -14,6 +14,19 @@ class TestRDConfig:
 
         assert list(config.elements_to_scan) == config.base_elements_to_scan[1:]
 
+    def test_include_no_exclude(self):
+        config = RDConfig()
+        config.included_resources = ['aws_bucket']
+
+        assert list(config.elements_to_scan) == config.included_resources
+
+    def test_include_with_excluded(self):
+        config = RDConfig()
+        config.exclude_resources = ['aws_s3_bucket']
+        config.included_resources = ['aws_vpc', 'aws_subnet']
+
+        assert list(config.elements_to_scan) == config.included_resources
+
     def test_singleton(self):
         config = RDConfig()
         config.regions = ['us-east-1', 'eu-west-1']


### PR DESCRIPTION
Fixes #45 
If anything is in `include-resource` it completely overrides `exclude-resource` so it's like starting from a blank list.

I went for `--include-resource` instead of `--only` so that the arguments are logically matched with `--exclude-resource`

Happy to change if others disagree